### PR TITLE
Change 2gb --> 2b

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ model is not included in the repository due to its size, but you can download it
 using the following command:
 
 ```shell
-humanify download 2gb
+humanify download 2b
 ```
 
-This downloads the `2gb` model to your local machine. This is only needed to do
+This downloads the `2b` model to your local machine. This is only needed to do
 once. You can also choose to download other models depending on your local
 resources. List the available models using `humanify download`.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "lint:prettier": "prettier --check src/* src/**/*",
     "lint:eslint": "eslint src/* src/**/*",
-    "download-ci-model": "npx humanify download 2gb"
+    "download-ci-model": "npx humanify download 2b"
   },
   "bin": {
     "humanify": "dist/index.mjs"

--- a/src/local-models.ts
+++ b/src/local-models.ts
@@ -15,7 +15,7 @@ const MODEL_DIRECTORY = join(homedir(), ".humanifyjs", "models");
 type ModelDefinition = { url: URL; wrapper?: ChatWrapper };
 
 export const MODELS: { [modelName: string]: ModelDefinition } = {
-  "2gb": {
+  "2b": {
     url: url`https://huggingface.co/bartowski/Phi-3.1-mini-4k-instruct-GGUF/resolve/main/Phi-3.1-mini-4k-instruct-Q4_K_M.gguf?download=true`
   },
   "8b": {


### PR DESCRIPTION
Refers to number of parameters in the model, not particularly the model size.

This is theoretically a breaking change since you could provide the model with `--model 2gb` previously, but since there was previously just one model, I think (hope) nobody actually used this flag yet