### PR TITLE
Allow setting non-default OpenAI base URLs

### DIFF
--- a/src/commands/openai.ts
+++ b/src/commands/openai.ts
@@ -15,6 +15,11 @@ export const openai = cli()
     "-k, --apiKey <apiKey>",
     "The OpenAI API key. Alternatively use OPENAI_API_KEY environment variable"
   )
+  .option(
+    "--baseURL <baseURL>",
+    "The OpenAI base server URL.",
+    env("OPENAI_BASE_URL") ?? "https://api.openai.com/v1"
+  )
   .option("--verbose", "Show verbose output")
   .argument("input", "The input minified Javascript file")
   .action(async (filename, opts) => {
@@ -23,9 +28,10 @@ export const openai = cli()
     }
 
     const apiKey = opts.apiKey ?? env("OPENAI_API_KEY");
+    const baseURL = opts.baseURL;
     await unminify(filename, opts.outputDir, [
       babel,
-      openaiRename({ apiKey, model: opts.model }),
+      openaiRename({ apiKey, baseURL, model: opts.model }),
       prettier
     ]);
   });

--- a/src/plugins/openai/openai-rename.ts
+++ b/src/plugins/openai/openai-rename.ts
@@ -5,12 +5,14 @@ import { verbose } from "../../verbose.js";
 
 export function openaiRename({
   apiKey,
+  baseURL,
   model
 }: {
   apiKey: string;
+  baseURL: string;
   model: string;
 }) {
-  const client = new OpenAI({ apiKey });
+  const client = new OpenAI({ apiKey, baseURL });
 
   return async (code: string): Promise<string> => {
     return await visitAllIdentifiers(


### PR DESCRIPTION
This is needed for using things like Cloudflare AI Gateway, [LiteLLM](https://github.com/jehna/humanify/issues/2#issuecomment-1819835316), etc.

Solves #68 for OpenAI