### PR TITLE
Fix slow model download speed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "babel-plugin-transform-beautifier": "^0.1.0",
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
+        "ipull": "^3.9.0",
         "node-llama-cpp": "^3.0.0-beta.40",
         "openai": "^4.55.1",
         "tsx": "^4.16.2",
@@ -2741,6 +2742,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
@@ -3984,14 +4000,15 @@
       "license": "ISC"
     },
     "node_modules/ipull": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.6.0.tgz",
-      "integrity": "sha512-oPN5iXxZ9xB3mHGS8zDZVJLgcXCSxy4lPNiNBrVVLDWaSJ7XlJIkn2CQRR5B8GI+aVi4HsiIfvXoJY402A+2pg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.0.tgz",
+      "integrity": "sha512-s/gZfxkfZKFJxojocTQwqWqtAxVzHKQZ0ivWvIAih3JpPN5mXkIOWzVm4/XKUmQELxan52REe3epRP69gfVQXg==",
       "license": "MIT",
       "dependencies": {
         "@tinyhttp/content-disposition": "^2.2.0",
         "async-retry": "^1.3.3",
         "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
         "cli-spinners": "^2.9.2",
         "commander": "^10.0.0",
         "eventemitter3": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "babel-plugin-transform-beautifier": "^0.1.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
+    "ipull": "^3.9.0",
     "node-llama-cpp": "^3.0.0-beta.40",
     "openai": "^4.55.1",
     "tsx": "^4.16.2",

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -1,5 +1,6 @@
 import { downloadModel, MODELS } from "../local-models.js";
 import { cli } from "../cli.js";
+import { verbose } from "../verbose.js";
 
 export function download() {
   const command = cli()
@@ -10,7 +11,13 @@ export function download() {
     command
       .command(model)
       .description(`Download the ${model} model`)
-      .action(() => downloadModel(model));
+      .option("-v, --verbose", "Show verbose output")
+      .action((opts) => {
+        if (opts.verbose) {
+          verbose.enabled = true;
+        }
+        downloadModel(model);
+      });
   }
 
   return command;


### PR DESCRIPTION
Using `ipull` should help with the download speed of the models, as it uses parallel connections to speed up the download.

Fixes #58