### PR TITLE
fix(cli): resolve `contextSize` as number instead of boolean

### DIFF
--- a/src/commands/gemini.ts
+++ b/src/commands/gemini.ts
@@ -14,7 +14,7 @@ export const azure = cli()
   .option("-m, --model <model>", "The model to use", "gemini-1.5-flash")
   .option("-o, --outputDir <output>", "The output directory", "output")
   .option(
-    "--contextSize",
+    "--contextSize <contextSize>",
     "The context size to use for the LLM",
     `${DEFAULT_CONTEXT_WINDOW_SIZE}`
   )

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -22,7 +22,7 @@ export const local = cli()
   .option("--disableGpu", "Disable GPU acceleration")
   .option("--verbose", "Show verbose output")
   .option(
-    "--contextSize",
+    "--contextSize <contextSize>",
     "The context size to use for the LLM",
     `${DEFAULT_CONTEXT_WINDOW_SIZE}`
   )

--- a/src/commands/openai.ts
+++ b/src/commands/openai.ts
@@ -24,7 +24,7 @@ export const openai = cli()
   )
   .option("--verbose", "Show verbose output")
   .option(
-    "--contextSize",
+    "--contextSize <contextSize>",
     "The context size to use for the LLM",
     `${DEFAULT_CONTEXT_WINDOW_SIZE}`
   )


### PR DESCRIPTION
### Changes:
- Updated the `--contextSize` option to ensure it is treated as a `number`, not a `boolean`.
