### PR TITLE
Fix strict mode crashing on arguments assign

### DIFF
--- a/src/plugins/local-llm-rename/visit-all-identifiers.test.ts
+++ b/src/plugins/local-llm-rename/visit-all-identifiers.test.ts
@@ -298,3 +298,20 @@ const bar = 2;
 `.trim()
   );
 });
+
+test("should not craash to 'arguments' assigning", async () => {
+  const code = `
+function foo() {
+  arguments = '??';
+}
+`.trim();
+  const result = await visitAllIdentifiers(code, async () => "foobar", 200);
+  assert.equal(
+    result,
+    `
+function foobar() {
+  arguments = '??';
+}
+    `.trim()
+  );
+});

--- a/src/plugins/local-llm-rename/visit-all-identifiers.ts
+++ b/src/plugins/local-llm-rename/visit-all-identifiers.ts
@@ -16,7 +16,7 @@ export async function visitAllIdentifiers(
   contextWindowSize: number,
   onProgress?: (percentageDone: number) => void
 ) {
-  const ast = await parseAsync(code);
+  const ast = await parseAsync(code, { sourceType: "script" });
   const renames = new Set<string>();
   const visited = new Set<string>();
 


### PR DESCRIPTION
The script was assumed to be in `strict` mode, which is the functionality of `sourceType: "module"`. This is wrong, as we cannot assume that the script would be in a strict mode.

Fixes #251