### PR TITLE
[dev-QoL] `.gitignore` `node_modules` + Jetbrains IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ dist
 test-output
 .env
 dist.tar.gz
+
+node_modules/
+
+.idea/


### PR DESCRIPTION
This is a tiny dev-QoL PR to add `node_modules/` and `.idea/` (Jetbrains IDE files) to the `.gitignore`

## See Also

- https://github.com/jehna/humanify/pull/309