### PR TITLE
[dev-QoL] add `debug` script to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "start": "tsx src/index.ts",
+    "debug": "node --inspect-brk ./node_modules/.bin/tsx src/index.ts",
     "build": "pkgroll",
     "deploy:patch": "npm version patch && npm run deploy:release",
     "deploy:minor": "npm version minor && npm run deploy:release",


### PR DESCRIPTION
This is a tiny dev Quality of Life PR that adds a simple `debug` script to `package.json` that allows running the app through `tsx` with `node`'s [`--inspect-brk`](https://nodejs.org/en/learn/getting-started/debugging#command-line-options) flag; which then allows connecting to it for remote debugging, eg. from `chrome:inspect` or similar:

```shell
⇒ npm run debug

> humanifyjs@2.2.2 debug
> node --inspect-brk ./node_modules/.bin/tsx src/index.ts

Debugger listening on ws://127.0.0.1:9229/b6551278-6c59-4156-9555-8c517afd509c
For help, see: https://nodejs.org/en/docs/inspector
```

`chrome://inspect/#devices`:

![image](https://github.com/user-attachments/assets/87ca262c-83c6-479a-b6a8-51ea96c60358)

![image](https://github.com/user-attachments/assets/3fc208b4-ff21-4b10-b4d2-4cb0cd246f60)

## See also

- https://nodejs.org/en/learn/getting-started/debugging
- https://github.com/jehna/humanify/pull/308