### PR TITLE
bump babel-plugin-transform-beautifier from 0.1.0 to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/types": "^7.25.2",
         "@google/generative-ai": "^0.20.0",
         "@types/babel__core": "^7.20.5",
-        "babel-plugin-transform-beautifier": "^0.1.0",
+        "babel-plugin-transform-beautifier": "^0.1.1",
         "commander": "^13.0.0",
         "dotenv": "^16.4.5",
         "ipull": "^3.9.0",
@@ -2489,9 +2489,9 @@
       }
     },
     "node_modules/babel-plugin-transform-beautifier": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-beautifier/-/babel-plugin-transform-beautifier-0.1.0.tgz",
-      "integrity": "sha512-odzHZZQCx6ppd5fSWsF/VmuZS8zn0UN8SCvNMTFuCKgPWwPI+BkUto3SDo7IBI9Y/A8yqFmsGYcU+2+f+fIT1A==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-beautifier/-/babel-plugin-transform-beautifier-0.1.1.tgz",
+      "integrity": "sha512-VP3RxAnJ857ZNHxU+cucYS0/B+msoc5CCFnjQeN1rwVFFE+VVegu5U/bEw+NWwav7ZVIjiTSNc1l/7BWxf1mVA==",
       "license": "MIT"
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/types": "^7.25.2",
     "@google/generative-ai": "^0.20.0",
     "@types/babel__core": "^7.20.5",
-    "babel-plugin-transform-beautifier": "^0.1.0",
+    "babel-plugin-transform-beautifier": "^0.1.1",
     "commander": "^13.0.0",
     "dotenv": "^16.4.5",
     "ipull": "^3.9.0",


### PR DESCRIPTION
> And thanks to @0xdevalias I found the root cause why your fork got rid of the error: the bug is in `babel-plugin-transform-beautifier`, which removes the async keyword.
> There are also many similar transforms that exist in humanify, webcrack and this plugin at the same time, might be a good idea to review which ones are needed. 
> 
> _Originally posted by @j4k0xb in https://github.com/jehna/humanify/issues/285#issuecomment-2660751350_

> > Upstream bug issue:
> > 
> > - https://github.com/gzzhanghao/babel-plugin-transform-beautifier/issues/3
> 
> > Fixed in v0.1.1 
> >
> > _Originally posted by @gzzhanghao in https://github.com/gzzhanghao/babel-plugin-transform-beautifier/issues/3#issuecomment-2661448752_
> 
> - https://github.com/gzzhanghao/babel-plugin-transform-beautifier/pull/5
>   - https://github.com/gzzhanghao/babel-plugin-transform-beautifier/blob/main/CHANGELOG.md#011
>   - https://www.npmjs.com/package/babel-plugin-transform-beautifier/v/0.1.1
> 
> _Originally posted by @0xdevalias in https://github.com/jehna/humanify/issues/285#issuecomment-2661687303_