### PR TITLE
Add `dry-run` subcommand for token-usage measurement

### DIFF
--- a/.issue-draft-v3-token-usage.md
+++ b/.issue-draft-v3-token-usage.md
@@ -1,0 +1,96 @@
+# v3 uses ~3× more tokens than v2 for the same input
+
+## Background
+
+In #724, @huyz reported after first trying v3:
+
+> I'm trying v3.
+> Just an initial comment: warning, it eats up a lot more tokens than the JS version
+
+To which @0xdevalias replied:
+
+> It would be interesting to side by side the old JS implementation with the new Rust one to see what's being sent as context / etc that would explain the extra token usage.
+
+This issue is the side-by-side. To keep it deterministic and independent of model output, both v2 and v3 were instrumented with a **dry-run** path that walks every identifier the real pipeline would walk, builds the exact `(system, user, schema)` triple that would be sent, tokenises it with `cl100k_base`, and reports totals — no LLM calls, no API keys.
+
+## Reproduction
+
+- v3: new `humanify dry-run <file>` subcommand on branch `claude/vigilant-noether-awdmR` (uses `tiktoken-rs`).
+- v2: standalone `dry-run.ts` script in a worktree at commit `5b30583^` (last v2-shaped commit before the Rust merge), using `tiktoken` from npm.
+
+Both report `calls`, `system/user/schema/total tokens`, and per-call averages.
+
+## Numbers
+
+### Fixture 1: `fixtures/example.min.js` (140 bytes, no shadowing)
+
+| metric | v2 (ctx=500) | v3 (ctx=500) | v3 / v2 |
+|---|---|---|---|
+| calls | 6 | 6 | 1.00× |
+| system tokens | 114 | 240 | 2.11× |
+| user tokens | 486 | 822 | 1.69× |
+| schema tokens | 342 | 234 | 0.68× |
+| **total tokens** | **942** | **1296** | **1.38×** |
+| avg total/call | 157 | 216 | 1.38× |
+
+### Fixture 2: 4 minified functions with shadowed `e, t, n, r, i, ...` (396 bytes)
+
+| metric | v2 (ctx=500) | v3 (ctx=500) | v3 / v2 |
+|---|---|---|---|
+| **calls** | **11** | **24** | **2.18×** |
+| system tokens | 209 | 960 | 4.59× |
+| user tokens | 1013 | 3799 | 3.75× |
+| schema tokens | 627 | 936 | 1.49× |
+| **total tokens** | **1849** | **5695** | **3.08×** |
+| avg total/call | 168 | 237 | 1.41× |
+
+## Where the extra tokens go
+
+Two independent multipliers stack:
+
+### 1. Walker iterates per binding, not per name → ~2.2× more calls
+
+- v2 `src/plugins/local-llm-rename/visit-all-identifiers.ts`: `visited` is a `Set<string>` keyed on the identifier **name**. Once `e` has been renamed once, every other `e` binding in any other scope is silently skipped.
+- v3 `src/rename/walker.rs`: `visited` is a `HashSet<SymbolId>` keyed on the **binding**. Each shadowed `e, t, n, r, ...` is a distinct symbol and gets its own LLM call.
+
+v3's behaviour is arguably more correct (different bindings can mean different things), but on real minified output — which leans hard on `a, b, c, d, e, t, n, r, i, o, s, u` reused in every closure — it multiplies the call count substantially.
+
+### 2. Larger per-call prompt template → ~1.4× more tokens per call
+
+v2 (`src/plugins/openai/openai-rename.ts`):
+
+```
+system: Rename Javascript variables/function `${name}` to have descriptive name based on their usage in the code."
+user:   <surroundingCode>
+```
+
+v3 (`src/llm/renamer.rs`):
+
+```
+system: You are a senior software engineer reviewing minified or obfuscated JavaScript.
+        Your job is to assign a single descriptive identifier name based on how the
+        variable is used in the surrounding code. Return JSON only.
+user:   Surrounding code:
+        ```javascript
+        <surroundingCode>
+        ```
+
+        The identifier currently named `<name>` appears in this code. Suggest a single
+        descriptive replacement name. Rules:
+        - camelCase for variables and functions, PascalCase for classes/constructors
+        - ASCII letters, digits, underscores only; first character must be a letter or underscore
+        - Avoid JavaScript reserved words
+        - If the current name is already meaningful, return it unchanged
+```
+
+The fenced code block, the "Rules:" enumeration, and the longer system role each add fixed per-call overhead — ~70–90 extra tokens before the surrounding code is even included.
+
+Note: the v3 default `--context-size` is **500** chars vs. v2's **1000**, so v3 already sends half as much surrounding code, and the overhead above is on top of that.
+
+## Possible next steps
+
+- Dedupe walker work by name where it's safe (e.g. cache rename decision for identical `(name, surrounding_code)` pairs).
+- Slim the per-call prompt: most of the `Rules:` block can be enforced post-hoc by the existing safe-name pipeline (`src/rename/safe_name.rs`) which already handles case, reserved words, and identifier-character normalisation — the model doesn't need to be told.
+- Make `--context-size` consistent with v2's old default, or document the change.
+
+I'm happy to take a swing at the prompt slim-down once we agree on direction.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +126,21 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -287,6 +311,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -472,6 +507,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tiktoken-rs",
  "tokio",
  "unicode-ident",
 ]
@@ -702,6 +738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e770254dd7802184595b1d30da2a15cb72569e2aca2b177aef8d22eac8a693"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,7 +889,7 @@ dependencies = [
  "allocator-api2",
  "hashbrown 0.17.0",
  "oxc_data_structures",
- "rustc-hash",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -911,7 +953,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -983,7 +1025,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "seq-macro",
 ]
 
@@ -1000,7 +1042,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "unicode-id-start",
 ]
 
@@ -1021,7 +1063,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "self_cell",
 ]
 
@@ -1033,7 +1075,7 @@ checksum = "6d378eb8bad20e89d66276aebab51f6a5408571092cac94abdd3eabb773713d6"
 dependencies = [
  "base64-simd",
  "json-escape-simd",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
 ]
@@ -1214,7 +1256,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror",
@@ -1234,7 +1276,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -1309,10 +1351,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1365,6 +1430,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1648,6 +1719,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.52.2", features = ["macros", "rt-multi-thread"] }
 async-trait = "0.1"
+tiktoken-rs = "0.11.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/cli/dry_run.rs
+++ b/src/cli/dry_run.rs
@@ -1,0 +1,174 @@
+use std::path::PathBuf;
+
+use tiktoken_rs::{cl100k_base, o200k_base, CoreBPE};
+
+use crate::llm::build_rename_prompt;
+use crate::pipe;
+use crate::rename::{rename_all_identifiers, RenameError, Renamer};
+
+pub struct Args {
+    pub input: String,
+    pub output: Option<PathBuf>,
+    pub context_size: usize,
+    pub tokenizer: String,
+}
+
+/// Dry-run: walks every identifier the real pipeline would walk, builds the
+/// exact prompt that would be sent, tokenises it, and prints per-call and
+/// aggregate token totals. No LLM calls, no API keys required.
+pub fn run(args: Args) -> i32 {
+    let bpe = match args.tokenizer.as_str() {
+        "cl100k_base" => match cl100k_base() {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("humanify: failed to load cl100k_base: {e}");
+                return 1;
+            }
+        },
+        "o200k_base" => match o200k_base() {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("humanify: failed to load o200k_base: {e}");
+                return 1;
+            }
+        },
+        other => {
+            eprintln!(
+                "humanify: unknown tokenizer '{other}'. Valid: cl100k_base, o200k_base"
+            );
+            return 64;
+        }
+    };
+
+    let source = match pipe::read_input(&args.input) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("humanify: failed to read input: {e}");
+            return 1;
+        }
+    };
+
+    let mut renamer = TokenCountingRenamer::new(bpe);
+
+    match rename_all_identifiers(&source, &mut renamer, args.context_size) {
+        Ok(_) => {}
+        Err(RenameError::Parse(msg)) => {
+            eprintln!("humanify: parse error: {msg}");
+            return 2;
+        }
+    }
+
+    let report = renamer.report(&args.tokenizer, args.context_size);
+
+    if let Err(e) = pipe::write_output(args.output.as_deref(), &report) {
+        eprintln!("humanify: failed to write output: {e}");
+        return 1;
+    }
+
+    0
+}
+
+struct TokenCountingRenamer {
+    bpe: CoreBPE,
+    calls: usize,
+    system_tokens: usize,
+    user_tokens: usize,
+    schema_tokens: usize,
+}
+
+impl TokenCountingRenamer {
+    fn new(bpe: CoreBPE) -> Self {
+        Self {
+            bpe,
+            calls: 0,
+            system_tokens: 0,
+            user_tokens: 0,
+            schema_tokens: 0,
+        }
+    }
+
+    fn count(&self, s: &str) -> usize {
+        self.bpe.encode_with_special_tokens(s).len()
+    }
+
+    fn report(&self, tokenizer: &str, context_size: usize) -> String {
+        let total = self.system_tokens + self.user_tokens + self.schema_tokens;
+        let avg_total = if self.calls == 0 {
+            0
+        } else {
+            total / self.calls
+        };
+        let avg_user = if self.calls == 0 {
+            0
+        } else {
+            self.user_tokens / self.calls
+        };
+        format!(
+            "humanify dry-run\n\
+             tokenizer       {tokenizer}\n\
+             context_size    {context_size}\n\
+             calls           {calls}\n\
+             system tokens   {sys}\n\
+             user tokens     {usr}\n\
+             schema tokens   {sch}\n\
+             total tokens    {total}\n\
+             avg total/call  {avg_total}\n\
+             avg user/call   {avg_user}\n",
+            calls = self.calls,
+            sys = self.system_tokens,
+            usr = self.user_tokens,
+            sch = self.schema_tokens,
+        )
+    }
+}
+
+impl Renamer for TokenCountingRenamer {
+    fn rename(&mut self, original: &str, surrounding_code: &str) -> String {
+        if original.is_empty() {
+            return String::new();
+        }
+        let (system, user, schema) = build_rename_prompt(original, surrounding_code);
+        let schema_str = serde_json::to_string(&schema).unwrap_or_default();
+        self.calls += 1;
+        self.system_tokens += self.count(system);
+        self.user_tokens += self.count(&user);
+        self.schema_tokens += self.count(&schema_str);
+        // Return the original name unchanged → walker short-circuits the
+        // safe-name pipeline for this binding, no double counting.
+        original.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(input: &str) -> Args {
+        Args {
+            input: input.to_string(),
+            output: None,
+            context_size: 500,
+            tokenizer: "cl100k_base".to_string(),
+        }
+    }
+
+    #[test]
+    fn unknown_tokenizer_returns_64() {
+        let mut a = args("irrelevant");
+        a.tokenizer = "garbage".to_string();
+        assert_eq!(run(a), 64);
+    }
+
+    #[test]
+    fn counts_calls_per_binding() {
+        let bpe = cl100k_base().unwrap();
+        let mut r = TokenCountingRenamer::new(bpe);
+        let src = "function a(b){var c=1;return b+c}";
+        rename_all_identifiers(src, &mut r, 500).unwrap();
+        // a, b, c → 3 bindings
+        assert_eq!(r.calls, 3);
+        assert!(r.system_tokens > 0);
+        assert!(r.user_tokens > 0);
+        assert!(r.schema_tokens > 0);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod dry_run;
 pub mod gemini;
 pub mod ollama;
 pub mod openai;

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -13,7 +13,7 @@ pub use anthropic::{AnthropicNativeJsonSchema, AnthropicToolCallAndPrompt};
 pub use http::{classify_error, HttpClient, StrategyError};
 pub use ladder::Ladder;
 pub use openai_compat::{ForcedToolCall, OpenAIJsonSchema, PromptToJson, ToolCallAndPrompt};
-pub use renamer::LlmRenamer;
+pub use renamer::{build_rename_prompt, LlmRenamer};
 
 #[async_trait]
 pub trait JsonStrategy: Send + Sync {

--- a/src/llm/renamer.rs
+++ b/src/llm/renamer.rs
@@ -6,7 +6,33 @@ use tokio::runtime::Handle;
 use crate::llm::ladder::Ladder;
 use crate::rename::Renamer;
 
-const SYSTEM_PROMPT: &str = "You are a senior software engineer reviewing minified or obfuscated JavaScript. Your job is to assign a single descriptive identifier name based on how the variable is used in the surrounding code. Return JSON only.";
+pub const SYSTEM_PROMPT: &str = "You are a senior software engineer reviewing minified or obfuscated JavaScript. Your job is to assign a single descriptive identifier name based on how the variable is used in the surrounding code. Return JSON only.";
+
+/// Builds the exact (system, user, schema) triple that `LlmRenamer::rename`
+/// would send for a given identifier. Exposed so the dry-run path tokenises
+/// the same bytes the real path would have sent.
+pub fn build_rename_prompt(
+    original: &str,
+    surrounding_code: &str,
+) -> (&'static str, String, serde_json::Value) {
+    let user = format!(
+        "Surrounding code:\n```javascript\n{surrounding_code}\n```\n\nThe identifier currently named `{original}` appears in this code. Suggest a single descriptive replacement name. Rules:\n- camelCase for variables and functions, PascalCase for classes/constructors\n- ASCII letters, digits, underscores only; first character must be a letter or underscore\n- Avoid JavaScript reserved words\n- If the current name is already meaningful, return it unchanged"
+    );
+    let schema = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+            "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 64,
+                "description": "The replacement identifier name."
+            }
+        }
+    });
+    (SYSTEM_PROMPT, user, schema)
+}
 
 /// Bridges the synchronous `Renamer` trait to the async `Ladder` via
 /// `tokio::runtime::Handle::block_on`.
@@ -33,27 +59,11 @@ impl Renamer for LlmRenamer {
             return String::new();
         }
 
-        let user = format!(
-            "Surrounding code:\n```javascript\n{surrounding_code}\n```\n\nThe identifier currently named `{original}` appears in this code. Suggest a single descriptive replacement name. Rules:\n- camelCase for variables and functions, PascalCase for classes/constructors\n- ASCII letters, digits, underscores only; first character must be a letter or underscore\n- Avoid JavaScript reserved words\n- If the current name is already meaningful, return it unchanged"
-        );
-
-        let schema = json!({
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["name"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 64,
-                    "description": "The replacement identifier name."
-                }
-            }
-        });
+        let (system, user, schema) = build_rename_prompt(original, surrounding_code);
 
         let result = self
             .runtime
-            .block_on(self.ladder.call(SYSTEM_PROMPT, &user, &schema));
+            .block_on(self.ladder.call(system, &user, &schema));
 
         match result {
             Ok(value) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{error::ErrorKind, Parser, Subcommand};
-use humanify::cli::{anthropic, gemini, ollama, openai, openrouter};
+use humanify::cli::{anthropic, dry_run, gemini, ollama, openai, openrouter};
 use std::path::PathBuf;
 
 const EXIT_CLI_USAGE: i32 = 64;
@@ -22,6 +22,27 @@ enum Commands {
     Anthropic(SubArgs),
     Ollama(SubArgs),
     Openrouter(SubArgs),
+    /// Walk identifiers like a real run, build the same prompt, and report
+    /// the token cost — without calling any LLM.
+    DryRun(DryRunArgs),
+}
+
+#[derive(Parser)]
+struct DryRunArgs {
+    /// Filename, or `-` for stdin
+    input: String,
+
+    /// Output file (default: stdout)
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Surrounding code chars per identifier
+    #[arg(long, default_value_t = 500)]
+    context_size: usize,
+
+    /// Tokenizer (cl100k_base or o200k_base)
+    #[arg(long, default_value = "cl100k_base")]
+    tokenizer: String,
 }
 
 #[derive(Parser)]
@@ -153,6 +174,12 @@ fn main() {
         Commands::Anthropic(args) => anthropic::run(into_anthropic_args(args)),
         Commands::Ollama(args) => ollama::run(into_ollama_args(args)),
         Commands::Openrouter(args) => openrouter::run(into_openrouter_args(args)),
+        Commands::DryRun(a) => dry_run::run(dry_run::Args {
+            input: a.input,
+            output: a.output,
+            context_size: a.context_size,
+            tokenizer: a.tokenizer,
+        }),
     };
 
     if exit_code != 0 {


### PR DESCRIPTION
## Summary

- New `humanify dry-run <file> [--context-size N] [--tokenizer cl100k_base|o200k_base]` subcommand. Walks every identifier the real pipeline would walk, builds the exact `(system, user, schema)` triple the LLM renamer would send, tokenises it via `tiktoken-rs`, and reports `calls` plus per-call and aggregate token totals. No LLM, no API key.
- Extracts `build_rename_prompt()` out of `LlmRenamer` so the dry-run path tokenises the exact bytes the real path would have sent — no chance of drift between the two.
- Used to produce the numbers in #749 (token-usage comparison vs. v2).

## Example

```
$ humanify dry-run fixtures/example.min.js
humanify dry-run
tokenizer       cl100k_base
context_size    500
calls           6
system tokens   240
user tokens     822
schema tokens   234
total tokens    1296
avg total/call  216
avg user/call   137
```

## Test plan

- [x] `cargo test --release` (186 passing, no regressions)
- [x] Manual run on `fixtures/example.min.js`
- [x] Manual run on a synthetic shadowing fixture (numbers match #749)
- [ ] Reviewer: try `humanify dry-run` on a real bundle and sanity-check the totals

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYuAm8hmd8HR8CR8xngogJ)_