### PR TITLE
Add Requesty preset

### DIFF
--- a/.github/workflows/e2e-requesty.yml
+++ b/.github/workflows/e2e-requesty.yml
@@ -1,0 +1,25 @@
+name: E2E Requesty
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    if: contains(github.event.pull_request.labels.*.name, 'test-requesty')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: e2e
+        run: cargo test --test e2e_requesty -- --ignored --nocapture
+        env:
+          REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cargo install --git https://github.com/jehna/humanify
 ### Usage
 
 ```shell
-humanify <openai|gemini|anthropic|ollama|openrouter> [FLAGS] <INPUT>
+humanify <openai|gemini|anthropic|ollama|openrouter|requesty> [FLAGS] <INPUT>
 ```
 
 * `<INPUT>` is a file path or `-` for stdin.
@@ -241,6 +241,24 @@ Default model: `openai/gpt-oss-120b`. For free-tier usage:
 
 ```shell
 humanify openrouter obfuscated.js -m qwen/qwen3-coder:free
+```
+
+### Requesty mode
+
+[Requesty](https://requesty.ai/) provides an OpenAI-compatible router across
+many backend models via a single API key.
+
+You'll need a Requesty API key. Sign up at https://requesty.ai/.
+
+```shell
+export REQUESTY_API_KEY=your-token
+humanify requesty obfuscated.js -o readable.js
+```
+
+Default model: `openai/gpt-4o-mini`. Override with `-m`:
+
+```shell
+humanify requesty obfuscated.js -m openai/gpt-4o-mini
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -255,10 +255,10 @@ export REQUESTY_API_KEY=your-token
 humanify requesty obfuscated.js -o readable.js
 ```
 
-Default model: `openai/gpt-4o-mini`. Override with `-m`:
+Default model: `nvidia/nemotron-3-super-120b-a12b`. Override with `-m`:
 
 ```shell
-humanify requesty obfuscated.js -m openai/gpt-4o-mini
+humanify requesty obfuscated.js -m nvidia/nemotron-3-super-120b-a12b
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ CI runs `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` on
 every PR. Provider e2e suites run against `gemini` (every PR, free tier)
 and `ollama` (every PR, runs on the GitHub runner). Other providers'
 e2e suites are label-gated (`test-openai`, `test-anthropic`,
-`test-openrouter`) to avoid burning API credits on every PR.
+`test-openrouter`, `test-requesty`) to avoid burning API credits on every PR.
 
 ## Star History
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,9 +4,11 @@ pub mod ollama;
 pub mod openai;
 pub mod openrouter;
 pub mod preset;
+pub mod requesty;
 
 pub use anthropic::run as run_anthropic;
 pub use gemini::run as run_gemini;
 pub use ollama::run as run_ollama;
 pub use openai::run as run_openai;
 pub use openrouter::run as run_openrouter;
+pub use requesty::run as run_requesty;

--- a/src/cli/requesty.rs
+++ b/src/cli/requesty.rs
@@ -4,7 +4,7 @@ use crate::cli::preset::{run_preset, PresetArgs, PresetDefaults, ProviderKind};
 
 pub const DEFAULTS: PresetDefaults = PresetDefaults {
     base_url: "https://router.requesty.ai/v1",
-    model: "openai/gpt-4o-mini",
+    model: "nvidia/nemotron-3-super-120b-a12b",
     api_key_env: "REQUESTY_API_KEY",
     provider_kind: ProviderKind::OpenAICompat,
     timeout_seconds: 60,
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn requesty_defaults_constants() {
         assert_eq!(DEFAULTS.base_url, "https://router.requesty.ai/v1");
-        assert_eq!(DEFAULTS.model, "openai/gpt-4o-mini");
+        assert_eq!(DEFAULTS.model, "nvidia/nemotron-3-super-120b-a12b");
         assert_eq!(DEFAULTS.api_key_env, "REQUESTY_API_KEY");
         assert!(matches!(DEFAULTS.provider_kind, ProviderKind::OpenAICompat));
     }

--- a/src/cli/requesty.rs
+++ b/src/cli/requesty.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+use crate::cli::preset::{run_preset, PresetArgs, PresetDefaults, ProviderKind};
+
+pub const DEFAULTS: PresetDefaults = PresetDefaults {
+    base_url: "https://router.requesty.ai/v1",
+    model: "openai/gpt-4o-mini",
+    api_key_env: "REQUESTY_API_KEY",
+    provider_kind: ProviderKind::OpenAICompat,
+    timeout_seconds: 60,
+};
+
+pub struct Args {
+    pub input: String,
+    pub output: Option<PathBuf>,
+    pub model: Option<String>,
+    pub api_key: Option<String>,
+    pub base_url: Option<String>,
+    pub context_size: usize,
+    pub json_mode: String,
+    pub verbose: bool,
+    pub timeout_seconds: Option<u64>,
+}
+
+impl From<Args> for PresetArgs {
+    fn from(a: Args) -> Self {
+        PresetArgs {
+            input: a.input,
+            output: a.output,
+            model: a.model,
+            api_key: a.api_key,
+            base_url: a.base_url,
+            context_size: a.context_size,
+            json_mode: a.json_mode,
+            verbose: a.verbose,
+            timeout_seconds: a.timeout_seconds,
+        }
+    }
+}
+
+pub fn run(args: Args) -> i32 {
+    run_preset(args.into(), DEFAULTS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requesty_defaults_constants() {
+        assert_eq!(DEFAULTS.base_url, "https://router.requesty.ai/v1");
+        assert_eq!(DEFAULTS.model, "openai/gpt-4o-mini");
+        assert_eq!(DEFAULTS.api_key_env, "REQUESTY_API_KEY");
+        assert!(matches!(DEFAULTS.provider_kind, ProviderKind::OpenAICompat));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{error::ErrorKind, Parser, Subcommand};
-use humanify::cli::{anthropic, gemini, ollama, openai, openrouter};
+use humanify::cli::{anthropic, gemini, ollama, openai, openrouter, requesty};
 use std::path::PathBuf;
 
 const EXIT_CLI_USAGE: i32 = 64;
@@ -22,6 +22,7 @@ enum Commands {
     Anthropic(SubArgs),
     Ollama(SubArgs),
     Openrouter(SubArgs),
+    Requesty(SubArgs),
 }
 
 #[derive(Parser)]
@@ -133,6 +134,20 @@ fn into_openrouter_args(a: SubArgs) -> openrouter::Args {
     }
 }
 
+fn into_requesty_args(a: SubArgs) -> requesty::Args {
+    requesty::Args {
+        input: a.input,
+        output: a.output,
+        model: a.model,
+        api_key: a.api_key,
+        base_url: a.base_url,
+        context_size: a.context_size,
+        json_mode: a.json_mode,
+        verbose: a.verbose,
+        timeout_seconds: a.timeout_seconds,
+    }
+}
+
 fn main() {
     let cli = match Cli::try_parse() {
         Ok(c) => c,
@@ -153,6 +168,7 @@ fn main() {
         Commands::Anthropic(args) => anthropic::run(into_anthropic_args(args)),
         Commands::Ollama(args) => ollama::run(into_ollama_args(args)),
         Commands::Openrouter(args) => openrouter::run(into_openrouter_args(args)),
+        Commands::Requesty(args) => requesty::run(into_requesty_args(args)),
     };
 
     if exit_code != 0 {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -147,6 +147,16 @@ impl JudgeConfig {
             timeout: Duration::from_secs(60),
         }
     }
+
+    pub fn requesty(model: &str) -> Self {
+        Self {
+            kind: JudgeKind::OpenAICompat,
+            base_url: "https://router.requesty.ai/v1".to_string(),
+            api_key: std::env::var("REQUESTY_API_KEY").ok(),
+            model: model.to_string(),
+            timeout: Duration::from_secs(60),
+        }
+    }
 }
 
 pub async fn judge_with(cfg: &JudgeConfig, code: &str) -> anyhow::Result<String> {
@@ -305,6 +315,11 @@ impl HumanifyCmdBuilder {
 
     pub fn openrouter(mut self) -> Self {
         self.subcommand = "openrouter".to_string();
+        self
+    }
+
+    pub fn requesty(mut self) -> Self {
+        self.subcommand = "requesty".to_string();
         self
     }
 

--- a/tests/e2e_requesty.rs
+++ b/tests/e2e_requesty.rs
@@ -6,10 +6,14 @@ use common::{given, humanify, JudgeConfig};
 #[ignore]
 async fn unminifies_example_file_with_requesty() {
     given("fixtures/example.min.js")
-        .judged_by(JudgeConfig::requesty("openai/gpt-4o-mini"))
+        .judged_by(JudgeConfig::requesty("nvidia/nemotron-3-super-120b-a12b"))
         .judge_says_minified()
         .await
-        .when(humanify().requesty().model("openai/gpt-4o-mini"))
+        .when(
+            humanify()
+                .requesty()
+                .model("nvidia/nemotron-3-super-120b-a12b"),
+        )
         .await
         .then_judge_says_one_of(&["EXCELLENT", "GOOD"])
         .await;

--- a/tests/e2e_requesty.rs
+++ b/tests/e2e_requesty.rs
@@ -1,0 +1,16 @@
+mod common;
+
+use common::{given, humanify, JudgeConfig};
+
+#[tokio::test]
+#[ignore]
+async fn unminifies_example_file_with_requesty() {
+    given("fixtures/example.min.js")
+        .judged_by(JudgeConfig::requesty("openai/gpt-4o-mini"))
+        .judge_says_minified()
+        .await
+        .when(humanify().requesty().model("openai/gpt-4o-mini"))
+        .await
+        .then_judge_says_one_of(&["EXCELLENT", "GOOD"])
+        .await;
+}


### PR DESCRIPTION
Adds a `requesty` preset, mirroring the existing `openrouter` preset.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `Authorization: Bearer` auth via `REQUESTY_API_KEY`.

Changes:
- `src/cli/requesty.rs` (new): a faithful copy of `src/cli/openrouter.rs` with `DEFAULTS` set to the Requesty base URL, `REQUESTY_API_KEY`, `ProviderKind::OpenAICompat`, default model `openai/gpt-4o-mini` (verified live).
- `src/cli/mod.rs`: module declaration + re-export.
- `src/main.rs`: `Requesty` clap subcommand variant + `into_requesty_args` + dispatch arm.
- `README.md`: usage synopsis + a Requesty mode section.

Verified with `cargo +1.92 build` (Finished, exit 0), `cargo fmt --check` clean, and the `requesty_defaults_constants` unit test passes. (The repo's deps require rustc ≥1.92; I built with that toolchain.)

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.