### PR TITLE
Include User-Agent header in LLM requests

### DIFF
--- a/src/llm/http.rs
+++ b/src/llm/http.rs
@@ -30,6 +30,7 @@ impl HttpClient {
         let mut request = self
             .inner
             .post(url)
+            .header("User-Agent", concat!("humanify/", env!("CARGO_PKG_VERSION")))
             .header("Content-Type", "application/json")
             .header("Accept", "application/json");
 


### PR DESCRIPTION
Add User-Agent header with package version to HTTP request this help prevent CDN like Cloudflare block when use custom provider like self-host omniroute/9route