### PR TITLE
Remove E2E tests needing API keys from fork pull requests

### DIFF
--- a/.github/workflows/e2e-anthropic.yml
+++ b/.github/workflows/e2e-anthropic.yml
@@ -10,7 +10,9 @@ concurrency:
 
 jobs:
   e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'test-anthropic')
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'test-anthropic')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-gemini.yml
+++ b/.github/workflows/e2e-gemini.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   e2e:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-openai.yml
+++ b/.github/workflows/e2e-openai.yml
@@ -10,7 +10,9 @@ concurrency:
 
 jobs:
   e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'test-openai')
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'test-openai')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-openrouter.yml
+++ b/.github/workflows/e2e-openrouter.yml
@@ -10,7 +10,9 @@ concurrency:
 
 jobs:
   e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'test-openrouter')
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'test-openrouter')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-requesty.yml
+++ b/.github/workflows/e2e-requesty.yml
@@ -10,7 +10,9 @@ concurrency:
 
 jobs:
   e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'test-requesty')
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'test-requesty')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -286,10 +286,12 @@ cargo test
 ```
 
 CI runs `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` on
-every PR. Provider e2e suites run against `gemini` (every PR, free tier)
-and `ollama` (every PR, runs on the GitHub runner). Other providers'
-e2e suites are label-gated (`test-openai`, `test-anthropic`,
-`test-openrouter`, `test-requesty`) to avoid burning API credits on every PR.
+every PR. Local `ollama` and judge e2e suites also run on every PR.
+The `gemini` e2e suite runs by default only for branches in this repository.
+Other providers' e2e suites require both a branch in this repository and
+their corresponding label (`test-openai`, `test-anthropic`,
+`test-openrouter`, `test-requesty`) to avoid exposing secrets to forks or
+burning API credits on every PR.
 
 ## Star History
 

--- a/src/cli/requesty.rs
+++ b/src/cli/requesty.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use crate::cli::preset::{run_preset, PresetArgs, PresetDefaults, ProviderKind};
 
 pub const DEFAULTS: PresetDefaults = PresetDefaults {
+    name: "requesty",
     base_url: "https://router.requesty.ai/v1",
     model: "nvidia/nemotron-3-super-120b-a12b",
     api_key_env: "REQUESTY_API_KEY",
@@ -16,9 +17,10 @@ pub struct Args {
     pub model: Option<String>,
     pub api_key: Option<String>,
     pub base_url: Option<String>,
-    pub context_size: usize,
-    pub json_mode: String,
+    pub context_size: Option<usize>,
+    pub json_mode: Option<String>,
     pub verbose: bool,
+    pub progress: bool,
     pub timeout_seconds: Option<u64>,
 }
 
@@ -33,6 +35,7 @@ impl From<Args> for PresetArgs {
             context_size: a.context_size,
             json_mode: a.json_mode,
             verbose: a.verbose,
+            progress: a.progress,
             timeout_seconds: a.timeout_seconds,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ fn into_requesty_args(a: SubArgs) -> requesty::Args {
         context_size: a.context_size,
         json_mode: a.json_mode,
         verbose: a.verbose,
+        progress: a.progress,
         timeout_seconds: a.timeout_seconds,
     }
 }


### PR DESCRIPTION
## Summary

- keep local CI, Ollama, and judge suites running for every pull request
- skip Gemini E2E for fork pull requests while retaining its default run for repository branches
- require both a repository branch and the provider label for OpenAI, Anthropic, OpenRouter, and Requesty E2E suites
- document the fork-safe E2E policy
- align Requesty with the shared preset interface after concurrent main-branch changes